### PR TITLE
PHP 8 fixes.

### DIFF
--- a/elysia_cron.drush.inc
+++ b/elysia_cron.drush.inc
@@ -88,7 +88,7 @@ function drush_elysia_cron_run_wrapper($op = false, $target = false) {
   if (!$verbose) {
     $verbose = drush_get_option("elysia-cron-verbose", false);
   }
-  $elysia_cron_drush = $quiet ? 1 : !$verbose ? 2 : 3; 
+  $elysia_cron_drush = $quiet ? 1 : (!$verbose ? 2 : 3);
   
   switch ($op) {
     case 'list':
@@ -109,8 +109,8 @@ function drush_elysia_cron_run_wrapper($op = false, $target = false) {
             $line[] = "Last run: " . elysia_cron_date(_ec_variable_get('elysia_cron_last_run', 0));
           }
         }
-        drush_print(implode($line, ", "));
-        foreach ($jobs as $job => $conf) if ($job{0} != '#') {
+        drush_print(implode(', ', $line));
+        foreach ($jobs as $job => $conf) if ($job[0] != '#') {
           if (!$verbose) {
             $line = array($job);
           } else {
@@ -128,7 +128,7 @@ function drush_elysia_cron_run_wrapper($op = false, $target = false) {
               $line[] = "Last run: " . elysia_cron_date($conf['last_run']);
             }
           }
-          drush_print(implode($line, ", "));
+          drush_print(implode(', ', $line));
         }
       }
       break;
@@ -138,7 +138,7 @@ function drush_elysia_cron_run_wrapper($op = false, $target = false) {
         elysia_cron_run(true, drush_get_option("ignore-disable", false), drush_get_option("ignore-time", false), drush_get_option("ignore-running", false));
         //drush_log("Cron run complete", "completed");
       }
-      elseif ($target{0} == '@') {
+      elseif ($target[0] == '@') {
         elysia_cron_initialize();
         if (elysia_cron_channel_exists(substr($target, 1))) {
           elysia_cron_run_channel(substr($target, 1), drush_get_option("ignore-disable", false), drush_get_option("ignore-time", false), drush_get_option("ignore-running", false));
@@ -161,7 +161,7 @@ function drush_elysia_cron_run_wrapper($op = false, $target = false) {
     case 'disable':
     case 'enable':
       if (!empty($target)) {
-        if ($target{0} == '@') {
+        if ($target[0] == '@') {
           elysia_cron_set_channel_disabled(substr($target, 1), $op == 'disable');
         } else {
           elysia_cron_set_job_disabled($target, $op == 'disable');

--- a/elysia_cron.module
+++ b/elysia_cron.module
@@ -776,7 +776,7 @@ function elysia_cron_decode_script($text, $apply = true) {
   foreach ($lines as $line) {
     $line = trim($line);
     if (!empty($line)) {
-      if ($line{0} == '#') {
+      if ($line[0] == '#') {
         $lastcomment = trim(substr($line, 1));
 
       }

--- a/elysia_drupalconv.php
+++ b/elysia_drupalconv.php
@@ -35,7 +35,7 @@ function _dcf_convert_render_array(&$a) {
 
 function _dcr_render_array($output) {
   foreach ($output as $k => &$v)
-    if ((is_numeric($k) || $k{0} != '#') && is_string($v))
+    if ((is_numeric($k) || $k[0] != '#') && is_string($v))
       $v = array( '#type' => 'markup', '#value' => $v, '#weight' => -1 );
   _dcf_convert_render_array($output);
   return drupal_render($output);
@@ -43,7 +43,7 @@ function _dcr_render_array($output) {
 
 function _dcr_form(&$form) {
   foreach ($form as $k => &$v)
-    if ((is_numeric($k) || $k{0} != '#') && is_string($v))
+    if ((is_numeric($k) || $k[0] != '#') && is_string($v))
       $v = array( '#type' => 'markup', '#value' => $v, '#weight' => -1 );
   _dcf_convert_render_array($form);
   return $form;


### PR DESCRIPTION
PHP 8 fixes:
- Nested ternary
- Curly bracket access syntax
- implode function signature